### PR TITLE
An admin cannot delete a user's task 

### DIFF
--- a/apps/website-rewrite/src/Controller/TaskController.php
+++ b/apps/website-rewrite/src/Controller/TaskController.php
@@ -82,7 +82,7 @@ class TaskController extends AbstractController
     }
 
     #[Route(path: '/tasks/{id}/delete', name: 'task_delete')]
-    #[IsGranted('TASK_TOGGLE', subject: 'task')]
+    #[IsGranted('TASK_DELETE', subject: 'task')]
     public function deleteTaskAction(Task $task, EntityManagerInterface $em): RedirectResponse
     {
         $em->remove($task);

--- a/apps/website-rewrite/src/Security/Voter/TaskVoter.php
+++ b/apps/website-rewrite/src/Security/Voter/TaskVoter.php
@@ -22,7 +22,7 @@ class TaskVoter extends Voter
      */
     protected function supports($attribute, $subject): bool
     {
-        return in_array($attribute, ['TASK_EDIT', 'TASK_TOGGLE', 'TASK_TOGGLE']) && $subject instanceof Task;
+        return in_array($attribute, ['TASK_EDIT', 'TASK_TOGGLE', 'TASK_DELETE']) && $subject instanceof Task;
     }
 
     /**

--- a/apps/website-rewrite/tests/Functionnal/Controllers/Task/DeleteTaskTest.php
+++ b/apps/website-rewrite/tests/Functionnal/Controllers/Task/DeleteTaskTest.php
@@ -56,7 +56,7 @@ class DeleteTaskTest extends TaskTest
         self::assertStringNotContainsString('Titre tâche ' . self::BELONGING_TO_ADMIN_TASK_ID, $crawler->html());
     }
 
-    public function testAnAdminCannotDeleteATaskOfAnotherUser()
+    public function testAnAdminCannotDeleteATaskOfAnotherUser(): void
     {
         $this->actingAsAdmin();
 

--- a/apps/website-rewrite/tests/Functionnal/Controllers/User/EditUserTest.php
+++ b/apps/website-rewrite/tests/Functionnal/Controllers/User/EditUserTest.php
@@ -93,7 +93,7 @@ class EditUserTest extends UserTestCase
 
         $this->client->submitForm('Modifier', [
             'user' => [
-                'username' => 'Utilisateur promu administrateur',
+                'username' => 'Utilisateur promu',
                 'password' => ['first' => 'password', 'second' => 'password'],
                 'email' => 'utilisateur-promu-administrateur@email.fr',
                 'role' => 'admin',
@@ -106,7 +106,7 @@ class EditUserTest extends UserTestCase
         self::assertStringContainsString("L'utilisateur a bien été modifié.", $crawler->html());
         self::assertContains(
             'ROLE_ADMIN',
-            $this->userRepository->findOneBy(['username' => 'Utilisateur promu administrateur'])->getRoles()
+            $this->userRepository->findOneBy(['username' => 'Utilisateur promu'])->getRoles()
         );
     }
 
@@ -121,7 +121,7 @@ class EditUserTest extends UserTestCase
 
         $this->client->submitForm('Modifier', [
             'user' => [
-                'username' => 'Administrateur déchu utilisateur',
+                'username' => 'Administrateur déchu',
                 'password' => ['first' => 'password', 'second' => 'password'],
                 'email' => 'administrateur-dechu-utilisateur@email.fr',
                 'role' => 'user',
@@ -133,7 +133,7 @@ class EditUserTest extends UserTestCase
         self::assertStringContainsString("L'utilisateur a bien été modifié.", $crawler->html());
         self::assertNotContains(
             'ROLE_ADMIN',
-            $this->userRepository->findOneBy(['username' => 'Administrateur déchu utilisateur'])->getRoles()
+            $this->userRepository->findOneBy(['username' => 'Administrateur déchu'])->getRoles()
         );
     }
 }


### PR DESCRIPTION
Fix the rights for an admin.

Before the fix, an admin could delete any user's task. Now an admin can only delete its own tasks and anonymous tasks.