### PR TITLE
Show a flash error message

### DIFF
--- a/apps/website-rewrite/config/packages/security.yaml
+++ b/apps/website-rewrite/config/packages/security.yaml
@@ -26,6 +26,8 @@ security:
             logout:
                 path: /logout
 
+            access_denied_handler: App\Security\WebAccessDeniedHandler
+
             # activate different ways to authenticate
             # https://symfony.com/doc/current/security.html#the-firewall
 

--- a/apps/website-rewrite/src/Controller/TaskController.php
+++ b/apps/website-rewrite/src/Controller/TaskController.php
@@ -48,7 +48,7 @@ class TaskController extends AbstractController
     }
 
     #[Route(path: '/tasks/{id}/edit', name: 'task_edit')]
-    #[IsGranted('TASK_EDIT', subject: 'task')]
+    #[IsGranted('TASK_EDIT', subject: 'task', message: "Vous n'avez pas le droit de modifier cette tâche.")]
     public function edit(Task $task, Request $request, EntityManagerInterface $em): RedirectResponse|Response
     {
         $form = $this->createForm(TaskType::class, $task);
@@ -70,7 +70,7 @@ class TaskController extends AbstractController
     }
 
     #[Route(path: '/tasks/{id}/toggle', name: 'task_toggle')]
-    #[IsGranted('TASK_TOGGLE', subject: 'task')]
+    #[IsGranted('TASK_TOGGLE', subject: 'task', message: "Vous n'avez pas le droit de basculer cette tâche.")]
     public function toggle(Task $task, EntityManagerInterface $em): RedirectResponse
     {
         $task->toggle(!$task->isDone());
@@ -82,7 +82,7 @@ class TaskController extends AbstractController
     }
 
     #[Route(path: '/tasks/{id}/delete', name: 'task_delete')]
-    #[IsGranted('TASK_DELETE', subject: 'task')]
+    #[IsGranted('TASK_DELETE', subject: 'task', message: "Vous n'avez pas le droit de supprimer cette tâche.")]
     public function deleteTaskAction(Task $task, EntityManagerInterface $em): RedirectResponse
     {
         $em->remove($task);

--- a/apps/website-rewrite/src/Security/WebAccessDeniedHandler.php
+++ b/apps/website-rewrite/src/Security/WebAccessDeniedHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\Security\Http\Authorization\AccessDeniedHandlerInterface;
+
+class WebAccessDeniedHandler implements AccessDeniedHandlerInterface
+{
+    public function handle(Request $request, AccessDeniedException $accessDeniedException): RedirectResponse
+    {
+        /** @var FlashBagInterface $flashBag */
+        $flashBag = $request->getSession()?->getFlashBag();
+
+        $message = $accessDeniedException->getMessage();
+
+        if ($message === "Access Denied.") {
+            $message = "Vous n'avez pas le droit d'accéder à cette page.";
+        }
+
+        $flashBag->add('error', $message);
+
+        return new RedirectResponse($request->headers->get('referer') ?? "/");
+    }
+}

--- a/apps/website-rewrite/templates/base.html.twig
+++ b/apps/website-rewrite/templates/base.html.twig
@@ -41,7 +41,7 @@
             {% endfor %}
 
             {% for flash_message in app.session.flashBag.get('error') %}
-                <div class="alert alert-danger" role="alert">
+                <div class="bg-red-200 text-red-900 rounded px-6 py-4 my-4" role="alert">
                     <strong>Oops !</strong> {{ flash_message }}
                 </div>
             {% endfor %}

--- a/apps/website-rewrite/tests/Functionnal/Controllers/ControllerTestCase.php
+++ b/apps/website-rewrite/tests/Functionnal/Controllers/ControllerTestCase.php
@@ -7,6 +7,7 @@ namespace App\Tests\Functionnal\Controllers;
 use App\Repository\UserRepository;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\Routing\RouterInterface;
 
 class ControllerTestCase extends WebTestCase
@@ -34,5 +35,10 @@ class ControllerTestCase extends WebTestCase
         $userRepository = static::getContainer()->get(UserRepository::class);
         $user = $userRepository->findOneByEmail('user@localhost');
         $this->client->loginUser($user);
+    }
+
+    public static function assertForbidden(Crawler $crawler, string $message): void
+    {
+        self::assertStringContainsString($message, $crawler->html());
     }
 }

--- a/apps/website-rewrite/tests/Functionnal/Controllers/Task/DeleteTaskTest.php
+++ b/apps/website-rewrite/tests/Functionnal/Controllers/Task/DeleteTaskTest.php
@@ -36,11 +36,9 @@ class DeleteTaskTest extends TaskTest
         $taskDeleteUrl = $this->generator->generate('task_delete', ['id' => self::BELONGING_TO_OTHER_USER_TASK_ID]);
 
         $this->client->request('GET', $taskDeleteUrl);
-        self::assertResponseStatusCodeSame(403);
-//        $crawler = $this->client->followRedirect();
-//
-//        self::assertRouteSame('task_list');
-//        self::assertStringContainsString('Impossible de modifier cette tâche', $crawler->html());
+        $crawler = $this->client->followRedirect();
+
+        self::assertForbidden($crawler, "Vous n'avez pas le droit de supprimer cette tâche.");
     }
 
     public function testAnAdminCanDeleteATaskHeOwns(): void
@@ -63,10 +61,8 @@ class DeleteTaskTest extends TaskTest
         $taskDeleteUrl = $this->generator->generate('task_delete', ['id' => self::BELONGING_TO_USER_TASK_ID]);
 
         $this->client->request('GET', $taskDeleteUrl);
-        self::assertResponseStatusCodeSame(403);
-//        $crawler = $this->client->followRedirect();
-//
-//        self::assertRouteSame('task_list');
-//        self::assertStringContainsString('Impossible de modifier cette tâche', $crawler->html());
+        $crawler = $this->client->followRedirect();
+
+        self::assertForbidden($crawler, "Vous n'avez pas le droit de supprimer cette tâche.");
     }
 }

--- a/apps/website-rewrite/tests/Functionnal/Controllers/Task/EditTaskTest.php
+++ b/apps/website-rewrite/tests/Functionnal/Controllers/Task/EditTaskTest.php
@@ -47,8 +47,9 @@ class EditTaskTest extends TaskTest
         $taskEditUrl = $this->generator->generate('task_edit', ['id' => self::BELONGING_TO_OTHER_USER_TASK_ID]);
 
         $this->client->request('GET', $taskEditUrl);
+        $crawler = $this->client->followRedirect();
 
-        self::assertResponseStatusCodeSame(403);
+        self::assertForbidden($crawler, "Vous n'avez pas le droit de modifier cette tâche.");
     }
 
     public function testAUserCannotEditAnAnonymousTask(): void
@@ -58,8 +59,9 @@ class EditTaskTest extends TaskTest
         $taskEditUrl = $this->generator->generate('task_edit', ['id' => self::ORPHAN_TASK_ID]);
 
         $this->client->request('GET', $taskEditUrl);
+        $crawler = $this->client->followRedirect();
 
-        self::assertResponseStatusCodeSame(403);
+        self::assertForbidden($crawler, "Vous n'avez pas le droit de modifier cette tâche.");
     }
 
     public function testAnAdminCanEditAnAnonymousTask(): void

--- a/apps/website-rewrite/tests/Functionnal/Controllers/Task/ToggleTaskTest.php
+++ b/apps/website-rewrite/tests/Functionnal/Controllers/Task/ToggleTaskTest.php
@@ -36,7 +36,8 @@ class ToggleTaskTest extends TaskTest
         $taskToggleUrl = $this->generator->generate('task_toggle', ['id' => self::BELONGING_TO_OTHER_USER_TASK_ID]);
 
         $this->client->request('GET', $taskToggleUrl);
+        $crawler = $this->client->followRedirect();
 
-        self::assertResponseStatusCodeSame(403);
+        self::assertForbidden($crawler, "Vous n'avez pas le droit de basculer cette tâche.");
     }
 }

--- a/apps/website-rewrite/tests/Functionnal/Controllers/User/CreateUserTest.php
+++ b/apps/website-rewrite/tests/Functionnal/Controllers/User/CreateUserTest.php
@@ -14,8 +14,9 @@ class CreateUserTest extends UserTestCase
 
         $userCreateUrl = $this->generator->generate('user_create');
         $this->client->request('GET', $userCreateUrl);
+        $crawler = $this->client->followRedirect();
 
-        self::assertResponseStatusCodeSame(403);
+        self::assertForbidden($crawler, "Vous n'avez pas le droit d'accéder à cette page.");
     }
 
     public function testAUserCannotCreateAUser(): void
@@ -35,8 +36,8 @@ class CreateUserTest extends UserTestCase
         $this->actingAsAdmin();
         $crawler = $this->client->request('GET', $userCreateUrl);
 
-        $this->assertResponseIsSuccessful();
-        $this->assertStringContainsString('Ajouter', $crawler->html());
+        self::assertResponseIsSuccessful();
+        self::assertStringContainsString('Ajouter', $crawler->html());
 
         $this->client->submitForm('Ajouter', [
             'user' => [

--- a/apps/website-rewrite/tests/Functionnal/Controllers/User/EditUserTest.php
+++ b/apps/website-rewrite/tests/Functionnal/Controllers/User/EditUserTest.php
@@ -25,8 +25,9 @@ class EditUserTest extends UserTestCase
 
         $userEditUrl = $this->generator->generate('user_edit', ['id' => UserFixture::ACTING_USER]);
         $this->client->request('GET', $userEditUrl);
+        $crawler = $this->client->followRedirect();
 
-        self::assertResponseStatusCodeSame(403);
+        self::assertForbidden($crawler, "Vous n'avez pas le droit d'accéder à cette page.");
     }
 
     public function testAnAdminCanEditUser(): void

--- a/apps/website-rewrite/tests/Functionnal/Controllers/User/ListUserTest.php
+++ b/apps/website-rewrite/tests/Functionnal/Controllers/User/ListUserTest.php
@@ -24,8 +24,9 @@ class ListUserTest extends UserTestCase
 
         $this->actingAsUser();
         $this->client->request('GET', $userListUrl);
+        $crawler = $this->client->followRedirect();
 
-        self::assertResponseStatusCodeSame(403);
+        self::assertForbidden($crawler, "Vous n'avez pas le droit d'accéder à cette page.");
     }
 
     public function testAnAdminCanSeeUserList(): void


### PR DESCRIPTION
When a user encounter a 403 error, it now shows a flash message to tell what's wrong instead of a raw 403 page.